### PR TITLE
 Add Outlook.com 550 5.7.515 SMTP error

### DIFF
--- a/data/codes/550.json
+++ b/data/codes/550.json
@@ -176,6 +176,13 @@
                     ]
                 },
                 {
+                    "response": "550 5.7.515 Access denied, sending domain example.com does not meet the required authentication level.",
+                    "description": "The 550 5.7.515 error means your message was rejected because it didn't meet Outlook’s authentication requirements for high-volume senders. If you're sending over 5,000 messages per day, your domain must pass SPF and DKIM, and have a DMARC policy in place.",
+                    "links": [
+                        "https:\/\/techcommunity.microsoft.com\/blog\/microsoftdefenderforoffice365blog\/strengthening-email-ecosystem-outlook%E2%80%99s-new-requirements-for-high%E2%80%90volume-senders\/4399730"
+                    ]
+                },
+                {
                     "response": "550 5.4.1 All recipient addresses rejected : Access denied [#.eop-nam02.prod.protection.outlook.com]",
                     "description": "This could be due to an active block on the sender for abuse reasons, but typically it's a policy that only specific senders\/servers are allowed to send mail to this host. Reach out the recipient directly for options to add the sender to their 'allow list'.",
                     "links": []


### PR DESCRIPTION
This PR adds the Outlook.com-specific SMTP error 550 5.7.515 to the list. As of today, Outlook.com is returning this error for high-volume senders (sending over 5,000 emails/day) whose messages fail SPF, DKIM, or DMARC checks.