### PR TITLE
Add Titan Email SMTP responses

### DIFF
--- a/data/codes/421.json
+++ b/data/codes/421.json
@@ -216,6 +216,19 @@
                     ]
                 }
             ]
+        },
+        {
+            "id": "titan",
+            "name": "Titan Email",
+            "responses": [
+                {
+                    "response": "421 4.7.0  : Sender IP rejected: sending IP has insufficient reputation.  Please retry later.",
+                    "description": "Your email couldn't be delivered because the sending IP address doesn't yet have sufficient reputation, as it's new in our system. This rejection is temporary—please try sending your email again later.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/data/codes/450.json
+++ b/data/codes/450.json
@@ -163,6 +163,19 @@
                     "links": []
                 }
             ]
+        },
+        {
+            "id": "titan",
+            "name": "Titan Email",
+            "responses": [
+                {
+                    "response": "450 4.2.0 <user@example.com>: Recipient address rejected: greylisted : please retry after sometime;",
+                    "description": "When an email is received from a suspicious IP address (often due to issues with reverse DNS), the server temporarily defers the message. The sending mail server is expected to hold the email for a short period before attempting to resend it. Subsequent retries from the sending server will then be accepted.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/data/codes/550.json
+++ b/data/codes/550.json
@@ -1037,6 +1037,123 @@
                     ]
                 }
             ]
+        },
+        {
+            "id": "titan",
+            "name": "Titan Email",
+            "responses": [
+                {
+                    "response": "550 5.5.1 Protocol error",
+                    "description": "Error message indicating that there is a problem with the way the email is being sent, usually related to the protocol commands or their sequence.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.1.8 <user@example.org>: Sender address rejected: Domain not found",
+                    "description": "Email rejected as no DNS MX and no DNS A record for the sender domain. These records specify the mail servers responsible for receiving emails on behalf of the sender domain. If an email cannot be delivered, a bounce message is sent back to the sender. Without proper MX and A records, the sender domain cannot receive these bounce messages, making it difficult to manage and rectify email delivery issues.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.7.27 <user@example.org>: Sender address rejected: Domain example.org does not accept mail (nullMX)",
+                    "description": "Email rejected as a malformed MX record such as a record with a zero-length MX hostname found for the sender domain",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.1.1 <user@example.com>: Recipient address rejected: User unknown in virtual mailbox table",
+                    "description": "Recipient email address does not exist",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.1.1 <user@example.com>: Recipient address rejected: User unknown in local recipient table",
+                    "description": "Recipient email address does not exist",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.7.1 <user@example.com>: Recipient address rejected: Message rejected due to: SPF fail - not authorized.",
+                    "description": "SPF Hard failure : The SPF record for the sender domain specifies a set of IP addresses that are allowed to send emails on behalf of that domain. If the IP address of the sending mail server is not listed in the SPF record of the sender domain, and the SPF record explicitly indicates that the IP address is not authorized (e.g., through the \"-all\" mechanism), the receiving mail server will consider the email as a hard failure.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.4.7 <user@example.com>: Recipient address rejected: Recipients Domain Hourly Quota Exceeded",
+                    "description": "Ratelimit exceeded https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive?utm_campaign=Titan+Support&utm_source=support-email",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive"
+                    ]
+                },
+                {
+                    "response": "550 5.4.7 <user@example.com>: Recipient address rejected: Recipients Domain Daily Quota Exceeded",
+                    "description": "Ratelimit exceeded https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive?utm_campaign=Titan+Support&utm_source=support-email",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive"
+                    ]
+                },
+                {
+                    "response": "550 5.4.6 <user@example.com>: Recipient address rejected: Recipient Quota Exceeded;",
+                    "description": "Ratelimit exceeded https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive?utm_campaign=Titan+Support&utm_source=support-email",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive"
+                    ]
+                },
+                {
+                    "response": "550 5.4.6 <user@example.com>: Recipient address rejected: Mailbox Does Not Exist : Domains Hourly Quota Exceeded;",
+                    "description": "Ratelimit exceeded https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive?utm_campaign=Titan+Support&utm_source=support-email",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive"
+                    ]
+                },
+                {
+                    "response": "550 5.4.6 <user@example.com>: Recipient address rejected: Mailbox Does Not Exist : Domains Daily Quota Exceeded;",
+                    "description": "Ratelimit exceeded https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive?utm_campaign=Titan+Support&utm_source=support-email",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive"
+                    ]
+                },
+                {
+                    "response": "550 5.7.1 message content rejected",
+                    "description": "Ratelimit exceeded https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive?utm_campaign=Titan+Support&utm_source=support-email",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/360038836914-How-many-emails-can-I-send-and-receive"
+                    ]
+                },
+                {
+                    "response": "550 5.2.1 <user@example.com>: Recipient address rejected: Incoming suspended due to abuse",
+                    "description": "This recipient domain is suspended due to suspicious activity , currently incoming emails are not getting accepted",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.2.1 <user@example.com> : Recipient address rejected: Incoming temporarily suspended due to partner migration",
+                    "description": "This domain is suspended due to ongoing partner migration, currently incoming emails are not being accepted.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "550 5.7.2 <ip>: Sender IP rejected: spam rate exceeded",
+                    "description": "Your email was rejected because the sending mail server has been sending an unusually high volume of spam or suspicious messages. To protect our users, we block emails from servers that exceed safe sending thresholds.",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/data/codes/552.json
+++ b/data/codes/552.json
@@ -156,6 +156,19 @@
                     ]
                 }
             ]
+        },
+        {
+            "id": "titan",
+            "name": "Titan Email",
+            "responses": [
+                {
+                    "response": "552 5.2.2 user@example.com: Recipient address rejected: Quota exceeded (mailbox for user is full)",
+                    "description": "Titan enforces disk quotas to ensure that users do not exceed their allocated storage space",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/data/codes/554.json
+++ b/data/codes/554.json
@@ -253,26 +253,26 @@
             "name": "Mimecast",
             "responses": [
                 {
-                "response": "554 Email rejected due to security policies (e.g., MCSpamSignature.x.x).",
-                "description": "A signature could be a virus or a spam score over the maximum threshold. The spam score isn't available in the Administration Console. If you aren't a Mimecast customer but have emails rejected with this error code, contact the recipient to adjust their configuration and permit your address. If unsuccessful, your IT department can- submit a request to review these email rejections via our Sender Feedback form linked below.",
-                "links": [
-                    "https:\/\/go.smtp.codes\/mimecastsenderfeedback"
-                ]
-            },
-            {
-                "response": "554 Mail loop detected.",
-                "description": "The message has too many Received Headers as it has been forwarded across multiple hops. Once 25 hops have been reached; the email is rejected.",
-                "links": [
-                    "https:\/\/mimecastsupport.zendesk.com\/hc\/en-us\/articles\/34000709564691-Policies-Mimecast-SMTP-Error-Codes"
-                ]
-            },
-            {
-                "response": "554 Host network not allowed.",
-                "description": "The message has triggered a Geographical Restriction policy set by the administrator.",
-                "links": [
-                    "https:\/\/mimecastsupport.zendesk.com\/hc\/en-us\/articles\/34000709564691-Policies-Mimecast-SMTP-Error-Codes"
-                ]
-            }
+                    "response": "554 Email rejected due to security policies (e.g., MCSpamSignature.x.x).",
+                    "description": "A signature could be a virus or a spam score over the maximum threshold. The spam score isn't available in the Administration Console. If you aren't a Mimecast customer but have emails rejected with this error code, contact the recipient to adjust their configuration and permit your address. If unsuccessful, your IT department can- submit a request to review these email rejections via our Sender Feedback form linked below.",
+                    "links": [
+                        "https:\/\/go.smtp.codes\/mimecastsenderfeedback"
+                    ]
+                },
+                {
+                    "response": "554 Mail loop detected.",
+                    "description": "The message has too many Received Headers as it has been forwarded across multiple hops. Once 25 hops have been reached; the email is rejected.",
+                    "links": [
+                        "https:\/\/mimecastsupport.zendesk.com\/hc\/en-us\/articles\/34000709564691-Policies-Mimecast-SMTP-Error-Codes"
+                    ]
+                },
+                {
+                    "response": "554 Host network not allowed.",
+                    "description": "The message has triggered a Geographical Restriction policy set by the administrator.",
+                    "links": [
+                        "https:\/\/mimecastsupport.zendesk.com\/hc\/en-us\/articles\/34000709564691-Policies-Mimecast-SMTP-Error-Codes"
+                    ]
+                }
             ]
         },
         {
@@ -420,6 +420,34 @@
                         "http:\/\/check.spamhaus.org",
                         "http:\/\/www.spamhaus.org\/pbl",
                         "https:\/\/www.secureserver.net\/help\/fix-rejected-email-with-a-bounce-error-40685?pl_id=3153&prog_id=3153#rbl"
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "titan",
+            "name": "Titan Email",
+            "responses": [
+                {
+                    "response": "554 5.7.1 <user@example.com>: Relay access denied;",
+                    "description": "Recipient email address does not exist",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
+                    ]
+                },
+                {
+                    "response": "554 5.7.1 Service unavailable; Client host [<ip>] blocked using b.barracudacentral.org;",
+                    "description": "IP address is found on an RBL, Titan rejected the email from that suspicious IP",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes",
+                        "http:\/\/b.barracudacentral.org"
+                    ]
+                },
+                {
+                    "response": "554 5.7.1 command rejected",
+                    "description": "IP address is suspicious, Titan rejected the email from that suspicious IP",
+                    "links": [
+                        "https:\/\/support.titan.email\/hc\/en-us\/articles\/35175377981977-Understanding-Incoming-Email-Reject-Codes"
                     ]
                 }
             ]

--- a/data/contributors.json
+++ b/data/contributors.json
@@ -2,7 +2,7 @@
   {
     "name": "Anna Ward",
     "url": "https://resend.com/blog/welcoming-anna-ward"
-  }, 
+  },
   {
     "name": "Derek Rushforth",
     "url": "https://derekrushforth.com"
@@ -46,5 +46,9 @@
   {
     "name": "Yannic Röcken",
     "url": "https://indeno.at"
+  },
+  {
+    "name": "Ankit Kulkarni",
+    "url": "https://i.ankul.in/"
   }
 ]

--- a/data/providers.json
+++ b/data/providers.json
@@ -220,7 +220,7 @@
             "protonmail.ch",
             "protonmail.com",
             "proton.me",
-            "pm.me" 
+            "pm.me"
         ],
         "description": "Proton Mail is a swiss-based email provider and the largest end-to-end encrypted email host. They do not have a postmaster page, but their team is very responsive via postmaster@proton.me",
         "links": []
@@ -353,6 +353,15 @@
         "description": "Zoho is a range of online services for businesses. It includes an email hosting product with spam filtering, firewall, and block list features.",
         "links": [
             "https:\/\/www.zoho.com\/mail\/help\/spam-reason.html"
+        ]
+    },
+    {
+        "id": "titan",
+        "name": "Titan Email",
+        "domains": [],
+        "description": "Titan Email is a hosted business email platform commonly resold by registrars and hosting providers for custom domains. Their SMTP responses frequently reflect recipient validation, sender authentication failures, anti-abuse enforcement, sender reputation checks, and inbound quota controls.",
+        "links": [
+            "https://support.titan.email/hc/en-us/articles/35175377981977-Understanding-Incoming-Email-Reject-Codes"
         ]
     }
 ]


### PR DESCRIPTION
## Summary
  - add Titan Email as a provider
  - add Titan SMTP responses under 421, 450, 550, 552, and 554
  - Adds name to contributers
  - Some space formatting changes to mimecast in 554.json 

